### PR TITLE
Replace references to BB_URL constants

### DIFF
--- a/html/mod_embed_contact.html.twig
+++ b/html/mod_embed_contact.html.twig
@@ -72,7 +72,7 @@
              $('#anti-spam').remove();
          
              $('#public-ticket-create').on('submit', function(event) {
-                 $.post("{{ constant('BB_URL_API') }}guest/support/ticket_create",
+                 $.post("{{ constant('SYSTEM_URL') }}api/guest/support/ticket_create",
                  $(this).serialize(),
                  function(json) {
                      if(json.error) {

--- a/html/mod_embed_domainchecker.html.twig
+++ b/html/mod_embed_domainchecker.html.twig
@@ -51,7 +51,7 @@
       <script>
          $(function() {
              $('#domain-checker').on('submit', function(event) {
-                 $.post("{{ constant('BB_URL_API') }}guest/servicedomain/check",
+                 $.post("{{ constant('SYSTEM_URL') }}api/guest/servicedomain/check",
                  $(this).serialize(),
                  function(json) {
                      if (json.error) {

--- a/html/mod_embed_loginform.html.twig
+++ b/html/mod_embed_loginform.html.twig
@@ -27,7 +27,7 @@
              form.addEventListener('submit', function(event) {
                  event.preventDefault();
                  var formData = new FormData(form);
-                 fetch("{{ constant('BB_URL_API') }}guest/client/login", {
+                 fetch("{{ constant('SYSTEM_URL') }}api/guest/client/login", {
                      method: 'POST',
                      body: new URLSearchParams(formData)
                  })
@@ -36,7 +36,7 @@
                      if(json.error) {
                          alert(json.error.message);
                      } else {
-                         window.location = "{{ constant('BB_URL') }}";
+                         window.location = "{{ constant('SYSTEM_URL') }}";
                      }
                  });
              });

--- a/html/mod_page_signup.html.twig
+++ b/html/mod_page_signup.html.twig
@@ -232,7 +232,7 @@ document.addEventListener("DOMContentLoaded", function() {
                            bb.msg(data.error.message, 'error');
                        }
                    } else {
-                       bb.redirect("{{ constant('BB_URL') }}");
+                       bb.redirect("{{ constant('SYSTEM_URL') }}");
                    }
                }
            });


### PR DESCRIPTION
Fix: #42 

Continuing the work laid out in #39, some references that were still utilizing ``BB_URL`` constants are now replaced with their ``SYSTEM_URL`` counterparts.