### PR TITLE
replace is empty by "/"

### DIFF
--- a/html/layout_default.html.twig
+++ b/html/layout_default.html.twig
@@ -430,7 +430,7 @@
                   <div class="row row-deck row-cards">
                      {% include "partial_message.html.twig" %}
                      {% if not client %}
-                     {% if request._url is empty %}
+                     {% if request._url == "/" %}
                      <div class="col-md-4">
                         <div class="card card-lg bg-red text-red-fg d-print-none">
                            <div class="card-stamp">


### PR DESCRIPTION
Replace condition of url being empty with url equals "/" because of a symfony update
---
From now, `request._url` will never be empty or undefined. instead, because of a symfony edit, default path will always be a "/"
<img width="640" height="375" alt="image" src="https://github.com/user-attachments/assets/5c1679f0-0133-49c8-9473-806b6c632179" />
 